### PR TITLE
repl: Fix panic when press return without any statement

### DIFF
--- a/cmd/abad/cli/cli.go
+++ b/cmd/abad/cli/cli.go
@@ -51,7 +51,10 @@ func (c *Cli) ReadEval() {
 		return
 	}
 
-	fmt.Fprintf(c.out, "< %s\n", obj.ToString().String())
+	if obj != nil {
+		fmt.Fprintf(c.out, "< %s\n", obj.ToString().String())
+	}
+
 }
 
 func (c *Cli) Repl() {


### PR DESCRIPTION
If I don't write anything, obj parsed it's nil, so calling
obj.ToString() tries dereferencing a nil pointer, which panic the
program.

I just modify the cli/cli.go ReadEval function to check if obj is nil
before trying to print the result.